### PR TITLE
✨ Add support for brightness control

### DIFF
--- a/src/components/topbar/ActionCenter/ActionCenter.tsx
+++ b/src/components/topbar/ActionCenter/ActionCenter.tsx
@@ -1,18 +1,21 @@
 import { mdiBluetooth, mdiKeyboard, mdiWifiStrength4 } from '@mdi/js';
+import { useAtom } from 'jotai';
 import styled, { css } from 'styled-components';
 import { AirDropSVG } from '__/assets/sf-icons/AirDrop.svg';
 import { MoonSVG } from '__/assets/sf-icons/Moon.svg';
 import { AppIcon } from '__/components/utils/AppIcon';
 import { ButtonBase } from '__/components/utils/ButtonBase';
 import { useTheme } from '__/hooks/use-theme';
+import { brightnessStore } from '__/stores/brightness.store';
 import { theme } from '__/theme';
 import { ACSlider } from './ACSlider';
 import { ActionCenterShell } from './ActionCenterShell';
 import { ActionCenterSurface } from './ActionCenterSurface';
 import { ActionCenterTile } from './ActionCenterTile';
 
-export const ActionCenter = ({}) => {
+export const ActionCenter = ({ }) => {
   const [theme, setTheme] = useTheme();
+  const [_, setBrightness] = useAtom(brightnessStore)
 
   const toggleTheme = () => setTheme(theme === 'light' ? 'dark' : 'light');
 
@@ -91,7 +94,12 @@ export const ActionCenter = ({}) => {
           ]}
         >
           <Label>Display</Label>
-          <ACSlider min={30} defaultValue={100} max={100} />
+          <ACSlider
+            onChange={(val) => setBrightness(val as number)}
+            min={0}
+            defaultValue={100}
+            max={100}
+          />
         </ActionCenterSurface>
 
         {/* Sound */}

--- a/src/components/topbar/ActionCenter/ActionCenterShell.tsx
+++ b/src/components/topbar/ActionCenter/ActionCenterShell.tsx
@@ -1,7 +1,9 @@
+import { useAtom } from 'jotai';
 import { ComponentChildren } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import styled, { css } from 'styled-components';
 import { useTheme } from '__/hooks/use-theme';
+import { brightnessStore } from '__/stores/brightness.store';
 import type { TTheme } from '__/stores/theme.store';
 import { theme } from '__/theme';
 
@@ -12,13 +14,16 @@ interface IMenuShell {
 export const ActionCenterShell = ({ children }: IMenuShell) => {
   const ref = useRef<HTMLElement>(null);
   const [theme] = useTheme();
+  const [brightness] = useAtom(brightnessStore)
 
   useEffect(() => {
     ref.current?.focus();
   }, []);
 
   return (
-    <Container theme={theme} ref={ref} tabIndex={-1}>
+    <Container 
+     style={{opacity: `${brightness}%`}}
+     theme={theme} ref={ref} tabIndex={-1}>
       {children}
     </Container>
   );

--- a/src/stores/brightness.store.ts
+++ b/src/stores/brightness.store.ts
@@ -1,0 +1,6 @@
+import { atom } from 'jotai';
+
+/**
+ * The store used to store the current brightness value
+ */
+export const brightnessStore = atom<number>(100);

--- a/src/views/desktop/Desktop.tsx
+++ b/src/views/desktop/Desktop.tsx
@@ -1,3 +1,4 @@
+import { useAtom } from 'jotai';
 import { useEffect } from 'preact/hooks';
 import styled, { createGlobalStyle } from 'styled-components';
 import { Reset } from 'styled-reset';
@@ -6,6 +7,7 @@ import { WindowsArea } from '__/components/Desktop/WindowsArea/WindowsArea';
 import { Dock } from '__/components/dock/Dock';
 import { TopBar } from '__/components/topbar/TopBar';
 import { useTheme } from '__/hooks/use-theme';
+import { brightnessStore } from '__/stores/brightness.store';
 import type { TTheme } from '__/stores/theme.store';
 
 const DarkBackground = '/assets/wallpapers/3-1.jpg';
@@ -13,6 +15,7 @@ const LightBackground = '/assets/wallpapers/3-2.jpg';
 
 export const Desktop = () => {
   const [theme] = useTheme();
+  const [brightness] = useAtom(brightnessStore)
 
   useEffect(() => {
     preloadImage(DarkBackground);
@@ -26,13 +29,13 @@ export const Desktop = () => {
       <Reset />
       <GlobalStyles />
 
-      <Main>
+      <Main style={{opacity: `${brightness}%`}}>
         <TopBar />
         <WindowsArea />
         <Dock />
       </Main>
 
-      <BackgroundCover theme={theme} aria-hidden="true" />
+      <BackgroundCover style={{opacity: `${brightness}%`}} theme={theme} aria-hidden="true" />
     </>
   );
 };
@@ -53,6 +56,8 @@ body {
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  background-color: #000;
 }
 
 * {


### PR DESCRIPTION
# Description

Adds support for brightness control using CSS opacity to `macos-web`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Changes

- Adds a new store `brightnessStore`
- Use the brightness to control the opacity at places
- Set the background color of the body to `#000` or black
