### PR TITLE
fix incorrect name of finder file menu item

### DIFF
--- a/src/data/menu/finder.menu.config.ts
+++ b/src/data/menu/finder.menu.config.ts
@@ -32,8 +32,8 @@ export const finderMenuConfig = createMenuConfig({
   file: {
     title: 'File',
     menu: {
-      'new-folder-window': {
-        title: 'New Folder Window',
+      'new-finder-window': {
+        title: 'New Finder Window',
       },
       'new-folder': {
         title: 'New Folder',
@@ -94,7 +94,7 @@ export const finderMenuConfig = createMenuConfig({
         disabled: true,
       },
       'show-original': {
-        title: 'Show original',
+        title: 'Show Original',
         disabled: true,
       },
       'add-to-sidebar': {


### PR DESCRIPTION
It should be like this:

<img width="414" alt="Screenshot 2021-04-15 at 5 26 27 PM" src="https://user-images.githubusercontent.com/61158210/114865430-d6c70f80-9e0f-11eb-9ea3-4865958a647e.png">

After the changes:

<img width="481" alt="Screenshot 2021-04-15 at 5 27 37 PM" src="https://user-images.githubusercontent.com/61158210/114865461-e2b2d180-9e0f-11eb-9084-c5db7f168095.png">

