### PR TITLE
feat(): traffic light icons on hover

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "scss.lint.validProperties": ["composes"]
 }

--- a/src/assets/traffic-icons/Close.svg.tsx
+++ b/src/assets/traffic-icons/Close.svg.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+function SvgComponent(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={7} height={7} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        stroke="#000"
+        strokeWidth={1.2}
+        strokeLinecap="round"
+        d="M1.182 5.99L5.99 1.182m0 4.95L1.182 1.323"
+      />
+    </svg>
+  );
+}
+
+export default SvgComponent;

--- a/src/assets/traffic-icons/Minimize.svg.tsx
+++ b/src/assets/traffic-icons/Minimize.svg.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+function SvgComponent(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={6} height={1} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path stroke="#000" strokeWidth={2} strokeLinecap="round" d="M.61.703h5.8" />
+    </svg>
+  );
+}
+
+export default SvgComponent;

--- a/src/assets/traffic-icons/Stretch.svg.tsx
+++ b/src/assets/traffic-icons/Stretch.svg.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+function SvgComponent(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 13 13"
+      xmlns="http://www.w3.org/2000/svg"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      strokeLinejoin="round"
+      strokeMiterlimit={2}
+      {...props}
+    >
+      <path d="M4.871 3.553L9.37 8.098V3.553H4.871zm3.134 5.769L3.506 4.777v4.545h4.499z" />
+      <circle cx={6.438} cy={6.438} r={6.438} fill="none" />
+    </svg>
+  );
+}
+
+export default SvgComponent;

--- a/src/components/Desktop/Window/TrafficLights.module.scss
+++ b/src/components/Desktop/Window/TrafficLights.module.scss
@@ -22,12 +22,12 @@
 
 .stretchLight {
   composes: trafficLight;
-  background-color: #ffbd2e;
-  box-shadow: 0 0 0 0.5px #dea123;
+  background-color: #27c93f;
+  box-shadow: 0 0 0 0.5px #1aab29;
 }
 
 .minimizeLight {
   composes: trafficLight;
-  background-color: #27c93f;
-  box-shadow: 0 0 0 0.5px #1aab29;
+  background-color: #ffbd2e;
+  box-shadow: 0 0 0 0.5px #dea123;
 }

--- a/src/components/Desktop/Window/TrafficLights.module.scss
+++ b/src/components/Desktop/Window/TrafficLights.module.scss
@@ -1,9 +1,17 @@
 .container {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.45rem;
 
   height: 100%;
+
+  &:hover svg {
+    visibility: visible;
+  }
+}
+
+svg {
+  visibility: hidden;
 }
 
 .trafficLight {

--- a/src/components/Desktop/Window/TrafficLights.tsx
+++ b/src/components/Desktop/Window/TrafficLights.tsx
@@ -2,6 +2,9 @@ import { useImmerAtom } from 'jotai/immer';
 import { ButtonBase } from '__/components/utils/ButtonBase';
 import { AppID, openAppsStore } from '__/stores/apps.store';
 import css from './TrafficLights.module.scss';
+import CloseIcon from '__/assets/traffic-icons/Close.svg';
+import MinimizeIcon from '__/assets/traffic-icons/Minimize.svg';
+import StretchIcon from '__/assets/traffic-icons/Stretch.svg';
 
 type TrafficLightProps = {
   appID: AppID;
@@ -23,9 +26,15 @@ export const TrafficLights = ({ appID, onMaximizeClick }: TrafficLightProps) => 
 
   return (
     <div className={css.container}>
-      <ButtonBase className={css.closeLight} onClick={closeApp} />
-      <ButtonBase className={css.minimizeLight} />
-      <ButtonBase className={css.stretchLight} onClick={maximizeApp} />
+      <ButtonBase className={css.closeLight} onClick={closeApp}>
+        <CloseIcon />
+      </ButtonBase>
+      <ButtonBase className={css.minimizeLight}>
+        <MinimizeIcon />
+      </ButtonBase>
+      <ButtonBase className={css.stretchLight} onClick={maximizeApp}>
+        <StretchIcon />
+      </ButtonBase>
     </div>
   );
 };

--- a/src/components/Desktop/Window/TrafficLights.tsx
+++ b/src/components/Desktop/Window/TrafficLights.tsx
@@ -24,8 +24,8 @@ export const TrafficLights = ({ appID, onMaximizeClick }: TrafficLightProps) => 
   return (
     <div className={css.container}>
       <ButtonBase className={css.closeLight} onClick={closeApp} />
-      <ButtonBase className={css.stretchLight} />
-      <ButtonBase className={css.minimizeLight} onClick={maximizeApp} />
+      <ButtonBase className={css.minimizeLight} />
+      <ButtonBase className={css.stretchLight} onClick={maximizeApp} />
     </div>
   );
 };


### PR DESCRIPTION
Attempt to Add Feature #63 

Changes Made:

#### Fix the Traffic Lights Name with sync to Scss

#### Fix this Linting Error:

<img width="484" alt="Screenshot 2021-04-15 at 11 32 20 PM" src="https://user-images.githubusercontent.com/61158210/114920547-2d037500-9e47-11eb-80ab-e735d2af1818.png">

#### Adding Feature of Traffic-Light Icons:
Svgs are TypeScript Components so that you can customize them further by passing `React.SVGProps<SVGSVGElement>` 
props.

#### Things you Might need to Consider in Future

<img width="415" alt="Screenshot 2021-04-16 at 12 06 27 AM" src="https://user-images.githubusercontent.com/61158210/114920922-98e5dd80-9e47-11eb-842b-4c4c22d5da46.png">

