### PR TITLE
tweaks to TrafficLights, expand Icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ web_modules
 node_modules
 dist/
 package-lock.json
+yarn.lock

--- a/src/assets/traffic-icons/Expand.svg.tsx
+++ b/src/assets/traffic-icons/Expand.svg.tsx
@@ -1,0 +1,17 @@
+export function ExpandIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.88 12.88" {...props}>
+      <circle cx="6.44" cy="6.44" r="6.44" style={{ fill: 'none' }} />
+      <path
+        d="M6.5,3.34V9.66M9.66,6.5H3.34"
+        style={{
+          fill: 'none',
+          stroke: 'black',
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round',
+          strokeWidth: 1.5,
+        }}
+      />
+    </svg>
+  );
+}

--- a/src/assets/traffic-icons/GreenLightIcon.tsx
+++ b/src/assets/traffic-icons/GreenLightIcon.tsx
@@ -1,0 +1,13 @@
+import { AppConfig } from '__/helpers/create-app-config';
+import { ExpandIcon } from './Expand.svg';
+import { StretchIcon } from './Stretch.svg';
+
+export type GreenLightProps = Pick<AppConfig, 'expandable'>;
+
+export const GreenLightIcon = ({ expandable }: GreenLightProps) => {
+  if (expandable) {
+    return <ExpandIcon />;
+  }
+
+  return <StretchIcon />;
+};

--- a/src/components/Desktop/Window/TrafficLights.module.scss
+++ b/src/components/Desktop/Window/TrafficLights.module.scss
@@ -42,6 +42,7 @@
   composes: trafficLight;
   --bgcolor: #27c93f;
   --border-color: #1aab29;
+  transform: rotate(90deg);
 }
 
 .minimizeLight {

--- a/src/components/Desktop/Window/TrafficLights.tsx
+++ b/src/components/Desktop/Window/TrafficLights.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx';
 import { useAtom } from 'jotai';
 import { useImmerAtom } from 'jotai/immer';
+import { appsConfig } from '__/data/apps/apps-config';
 import { CloseIcon } from '__/assets/traffic-icons/Close.svg';
 import { MinimizeIcon } from '__/assets/traffic-icons/Minimize.svg';
-import { StretchIcon } from '__/assets/traffic-icons/Stretch.svg';
+import { GreenLightIcon } from '__/assets/traffic-icons/GreenLightIcon';
 import { ButtonBase } from '__/components/utils/ButtonBase';
 import { activeAppStore, AppID, openAppsStore } from '__/stores/apps.store';
 import css from './TrafficLights.module.scss';
@@ -24,8 +25,12 @@ export const TrafficLights = ({ appID, onMaximizeClick, class: className }: Traf
       return openApps;
     });
 
-  const maximizeApp = () => {
-    onMaximizeClick();
+  const greenLightAction = () => {
+    if (appsConfig[appID].expandable) {
+      // Action not available right now!
+    } else {
+      onMaximizeClick();
+    }
   };
 
   return (
@@ -36,8 +41,8 @@ export const TrafficLights = ({ appID, onMaximizeClick, class: className }: Traf
       <ButtonBase class={css.minimizeLight}>
         <MinimizeIcon />
       </ButtonBase>
-      <ButtonBase class={css.stretchLight} onClick={maximizeApp}>
-        <StretchIcon />
+      <ButtonBase class={css.stretchLight} onClick={greenLightAction}>
+        <GreenLightIcon {...appsConfig[appID]} />
       </ButtonBase>
     </div>
   );

--- a/src/data/apps/calculator.app-config.ts
+++ b/src/data/apps/calculator.app-config.ts
@@ -3,6 +3,9 @@ import { createAppConfig } from '__/helpers/create-app-config';
 export const calculatorAppConfig = createAppConfig({
   title: 'Calculator',
 
+  expandable: true,
+  resizable: false,
+
   height: 300 * 1.414,
   width: 300,
 

--- a/src/helpers/create-app-config.ts
+++ b/src/helpers/create-app-config.ts
@@ -2,6 +2,7 @@ export type AppConfig = {
   title: string;
 
   resizable?: boolean;
+  expandable?: boolean;
   height?: string | number;
   width?: string | number;
 


### PR DESCRIPTION
1. Rotated the Stretch icon
2. Added expand (+) icon for apps like calculator

<img width="344" alt="Screen Shot 2021-04-20 at 12 40 27" src="https://user-images.githubusercontent.com/45141388/115374690-c0390380-a1d5-11eb-958e-466de6264eea.png">
