### PR TITLE
Hide `backdrop-filter` outline on dock

### DIFF
--- a/src/components/Dock/Dock.svelte
+++ b/src/components/Dock/Dock.svelte
@@ -57,6 +57,8 @@
 
     &::before {
       content: '';
+      
+      border-radius: 20px;
 
       width: 100%;
       height: 100%;


### PR DESCRIPTION
If the dock has a window underneath then you can see the outline of the rectangular blur filter
![image](https://user-images.githubusercontent.com/26971/129442505-2f503e6f-6302-4f70-a068-c6662126e3f9.png)



You can fix this with a `border-radius` of `20px`.

![image](https://user-images.githubusercontent.com/26971/129442495-093f29be-61d1-4e8e-9a70-0521bbd1437f.png)
