### PR TITLE
fix: ActionCenterTile defaults to `<button>`

### DIFF
--- a/src/components/TopBar/ActionCenter.svelte
+++ b/src/components/TopBar/ActionCenter.svelte
@@ -50,10 +50,10 @@
       [1, 2],
     ]}
   >
-    <ActionCenterTile grid={[1, 1]}>
-      <button class="toggle" class:filled={$theme.scheme === 'dark'} on:click={toggleTheme}>
+    <ActionCenterTile grid={[1, 1]} on:click={toggleTheme}>
+      <span class="toggle-icon" class:filled={$theme.scheme === 'dark'}>
         <DarkMode />
-      </button>
+      </span>
       Dark mode
     </ActionCenterTile>
   </ActionCenterSurface>
@@ -64,14 +64,10 @@
       [1, 2],
     ]}
   >
-    <ActionCenterTile grid={[1, 1]}>
-      <button
-        class="toggle"
-        class:filled={!$prefersReducedMotion}
-        on:click={toggleMotionPreference}
-      >
+    <ActionCenterTile grid={[1, 1]} on:click={toggleMotionPreference}>
+      <span class="toggle-icon" class:filled={!$prefersReducedMotion}>
         <TransitionMaskedIcon />
-      </button>
+      </span>
       Animations
     </ActionCenterTile>
   </ActionCenterSurface>
@@ -82,7 +78,7 @@
       [3, 2],
     ]}
   >
-    <ActionCenterTile grid={[1, 1]}>
+    <ActionCenterTile grid={[1, 1]} role="region">
       <div class="color-picker">
         <p>System Color</p>
         <div class="color-palette">
@@ -108,12 +104,7 @@
       [5, 3],
     ]}
   >
-    <ActionCenterTile
-      focusable={true}
-      grid={[1, 1]}
-      on:click={openWallpapersApp}
-      on:keyup={(e) => ['Enter', 'Space Bar'].includes(e.key) && openWallpapersApp()}
-    >
+    <ActionCenterTile grid={[1, 1]} on:click={openWallpapersApp}>
       <div class="wallpaper-tile">
         <img
           class="wallpaper-thumbnail"
@@ -176,7 +167,7 @@
     }
   }
 
-  .toggle {
+  .toggle-icon {
     --size: 1.7rem;
 
     --bgcolor: var(--system-color-dark-hsl);
@@ -191,6 +182,7 @@
     padding: 0;
 
     display: flex;
+    justify-content: center;
     place-items: center;
 
     border-radius: 50%;

--- a/src/components/TopBar/ActionCenterTile.svelte
+++ b/src/components/TopBar/ActionCenterTile.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
   export let grid: [rowStart: number, rowSpan: number];
-  export let focusable = false;
+  export let role = 'button';
 
   const [rowStart, rowsPan] = grid;
 </script>
 
-<div
+<button
   class="container"
   style="grid-row: {rowStart} / span {rowsPan}"
-  tabindex={focusable ? 0 : -1}
+  tabindex={role === 'button' ? 0 : -1}
   on:click
   on:keyup
+  {role}
 >
   <slot />
-</div>
+</button>
 
 <style>
   .container {
@@ -26,5 +27,6 @@
     font-size: 0.85rem;
     font-weight: 600;
     color: var(--system-color-dark);
+    text-align: start;
   }
 </style>


### PR DESCRIPTION
Currently a user needs to press the icon _inside_ an ActionCenterTile to toggle dark theme or animations.
If the whole ActionCenterTile would be clickable the touch/click target would be bigger and easier to use.

I tried to find a solution that respects semantics and roles. I am not an a11y expert, but it should be fine:

* The ActionCenterTile component now defaults to a `<button>` element instead of a `<div>`. This makes clickable tiles have the default button behavior, i.e. it's focus-able and also eliminates the need to manually listen to `on:keyup`.

* Inside the ActionCenterTile I've also added `text-align: start` to override the default browser behavior of centered button text. The styles slightly changed because the tile is a `<button>` now, but it looks "correct", to me at least 😅

* Since the tile for system color is not a clickable tile, I've added a role input, so we can tell the browser that this tile is a `region` (which is the role of a `<section>` element). 
  * This is the part I'm not 100% sure on a11y/semantics wise btw.

* The icons now get wrapped in a `<span>` instead of a `<button>` and I've renamed the class to be more accurate. I've also added `justify-content: center` to the class to correctly align the icon. Of course I've also moved the `on:click` events to the wrapping ActionCenterTile component.

_i hope i am doing this somewhat right, this is my first real oss pr_

:v: Peace out 😄 
