### PR TITLE
Configure Gitpod ports, extensions & prebuilds.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,17 @@
 tasks:
   - init: npm install
     command: npm run dev
+
+ports:
+  - port: 3000
+    onOpen: open-browser
+
+vscode:
+  extensions:
+    - svelte.svelte-vscode
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true


### PR DESCRIPTION
Hi Puru,

I wanted to add a Gitpod config file and noticed you already beat me to it 😅.

This PR adds a bit more automation, in particular:
- It automatically opens the web app in a new browser tab
- The Svelte VS Code is installed automatically
- [Prebuilds](https://www.gitpod.io/docs/prebuilds) are configured. Please follow [these three steps](https://www.gitpod.io/docs/prebuilds#on-github) to enable it for the project repository.

Prebuilds will automatically run the `init` task whenever code changes in your repo, so you never have to wait for `npm install` ever again 😀.

You can test the changes in this PR by clicking the following button:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/PuruVJ/macos-web/pull/25)

Let me know if you have any questions.

Best,

Mike