### PR TITLE
fix(calendar): use keys to avoid stale styles when switching months

### DIFF
--- a/src/components/apps/Calendar/MonthView.svelte
+++ b/src/components/apps/Calendar/MonthView.svelte
@@ -17,6 +17,10 @@
     );
   }
 
+  function dayKey(date) {
+    return [date, selectedDate.getMonth()].join('-');
+  }
+
   $: ({ daysInPrevMonth, daysInThisMonth, daysInNextMonth } = getDisplayDays(selectedDate));
 </script>
 
@@ -25,19 +29,19 @@
     <div class="weekday" class:weekend={[5, 6].includes(i)}>{day}</div>
   {/each}
 
-  {#each daysInPrevMonth as date (date)}
+  {#each daysInPrevMonth as date (dayKey(date))}
     <div class="day" class:today={isToday(date, false)}>
       <div class="date-number" class:this-month={false}>{date}</div>
     </div>
   {/each}
 
-  {#each daysInThisMonth as date (date)}
+  {#each daysInThisMonth as date (dayKey(date))}
     <div class="day" class:today={isToday(date, true)}>
       <div class="date-number" class:this-month={true}>{date}</div>
     </div>
   {/each}
 
-  {#each daysInNextMonth as date (date)}
+  {#each daysInNextMonth as date (dayKey(date))}
     <div class="day" class:today={isToday(date, false)}>
       <div class="date-number" class:this-month={false}>{date}</div>
     </div>


### PR DESCRIPTION
The key used is the currently selected month, even if technically there could be a slight improvement if those few days of the next month are still visible when you switch months, I didn't think that was worth the extra code it would bring.

Here's a video showing a before/after of this PR

https://user-images.githubusercontent.com/6270048/144886473-ecb2ac13-43f0-4828-8e98-7340e614f405.mov

