### PR TITLE
feat: menu bar drop down padding

### DIFF
--- a/src/components/TopBar/ActionCenter.svelte
+++ b/src/components/TopBar/ActionCenter.svelte
@@ -156,6 +156,8 @@
 
     padding: 0.75rem;
 
+    margin-top: 5px;
+
     position: relative;
 
     user-select: none;

--- a/src/components/TopBar/MenuBar.svelte
+++ b/src/components/TopBar/MenuBar.svelte
@@ -32,7 +32,10 @@
 
       <div
         class="menu-parent"
-        style="visibility: {$activeMenu !== menuID ? 'hidden' : 'visible'}"
+        style="visibility: {$activeMenu !== menuID ? 'hidden' : 'visible'}; margin-left: {menuID ===
+        'apple'
+          ? '5px'
+          : '0'}"
         use:elevation={'menubar-menu-parent'}
       >
         <Menu menu={menuConfig.menu} />
@@ -44,6 +47,7 @@
 <style lang="scss">
   .container {
     height: 100%;
+    margin-top: 5px;
 
     display: flex;
     position: relative;


### PR DESCRIPTION
In macOS, there is some padding on dropdown items. This PR adds that padding to menu bar items. Cool project!

<img width="377" alt="Screen Shot 2021-12-24 at 11 39 24 AM" src="https://user-images.githubusercontent.com/43759105/147365061-dd96efa6-8627-4245-b50d-205fb24bd697.png">

Signed-off-by: Matt Gleich <git@mattglei.ch>