### PR TITLE
fix the open apps bigger than window.innerHeight

### DIFF
--- a/src/components/Desktop/Window/Window.svelte
+++ b/src/components/Desktop/Window/Window.svelte
@@ -31,6 +31,8 @@
 
   const { height, width } = appsConfig[appID];
 
+  const remModifier = +height * 1.2 >= window.innerHeight ? 24 : 16;
+
   const randX = randint(-600, 600);
   const randY = randint(-100, 100);
 
@@ -76,8 +78,8 @@
       draggingEnabled = true;
       windowEl.style.transform = minimizedTransform;
 
-      windowEl.style.width = `${+width / 16}rem`;
-      windowEl.style.height = `${+height / 16}rem`;
+      windowEl.style.width = `${+width / remModifier}rem`;
+      windowEl.style.height = `${+height / remModifier}rem`;
     }
 
     isMaximized = !isMaximized;
@@ -110,7 +112,7 @@
   class="container"
   class:dark={$theme.scheme === 'dark'}
   class:active={$activeApp === appID}
-  style="width: {+width / 16}rem;height: {+height / 16}rem; z-index: {$appZIndices[appID]}"
+  style="width: {+width / remModifier}rem;height: {+height / remModifier}rem; z-index: {$appZIndices[appID]}"
   tabindex="-1"
   bind:this={windowEl}
   use:draggable={{


### PR DESCRIPTION
## This PR fix this issue #31 

### What was happened?

The main problem was caused because the apps has fixed width and height. So and when a app, that has the height bigger than the `Window` component height tried to open, the `TopBar` and `Dock` components were pushed to up.

### What I did?

I implemented a way to set the height and the width of an app dynamically, based in the window height. Basically, I used the math that already existed in the code, which was `value / 16` to `value / 24` when the app height + 20% is greater than the window height.

If I write this rule without code, this would be something like this:

*If the height of the app, plus 20%, you are trying to open is greater than the window height, so open the app a little bit smaller than your normal size, else open the app with your normal size.*