### PR TITLE
outward curves in notch

### DIFF
--- a/src/components/TopBar/TopBar.svelte
+++ b/src/components/TopBar/TopBar.svelte
@@ -83,6 +83,25 @@
         opacity: 1;
       }
     }
+
+    // for outward curves
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      height: 16px;
+      width: 16px;
+      border-radius: 50%;
+    }
+    &::before {
+      left: -16px;
+      box-shadow: 8px -8px #222;
+    }
+    &::after {
+      right: -16px;
+      box-shadow: -8px -8px #222;
+    }
   }
 
   header::before {


### PR DESCRIPTION
| ![image](https://user-images.githubusercontent.com/89068816/175774526-2fb73436-19cb-4f1c-98db-8762016a3fb2.png) | ![image](https://user-images.githubusercontent.com/89068816/175774508-dc944ffb-45ab-4373-b619-dc436596a3d6.png) |
|-|-|
| before | after |

also ig the notch would look closer to real with black background instead of #222 (which is being currently used)