### PR TITLE
feat: update unplugin icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
 		"@neodrag/svelte": "^2.0.6",
 		"date-fns": "^4.1.0",
 		"popmotion": "^11.0.5",
-		"unplugin-icons": "^0.19.3"
+		"unplugin-icons": "^0.20.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
       unplugin-icons:
-        specifier: ^0.19.3
-        version: 0.19.3(webpack-sources@3.2.3)
+        specifier: ^0.20.0
+        version: 0.20.0(svelte@5.1.4)(webpack-sources@3.2.3)
     devDependencies:
       '@iconify-json/gg':
         specifier: ^1.2.1
@@ -2054,12 +2054,13 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unplugin-icons@0.19.3:
-    resolution: {integrity: sha512-EUegRmsAI6+rrYr0vXjFlIP+lg4fSC4zb62zAZKx8FGXlWAGgEGBCa3JDe27aRAXhistObLPbBPhwa/0jYLFkQ==}
+  unplugin-icons@0.20.0:
+    resolution: {integrity: sha512-817iCV6AMADLHHcs9R15XII5Jaz++thnaQRzXbd0IZDcxi43iekoKENpuxqZN3k3+aOqJfqxcZ6I8POJ35UCEA==}
     peerDependencies:
       '@svgr/core': '>=7.0.0'
       '@svgx/core': ^1.0.1
       '@vue/compiler-sfc': ^3.0.2 || ^2.7.0
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
       vue-template-compiler: ^2.6.12
       vue-template-es2015-compiler: ^1.9.0
     peerDependenciesMeta:
@@ -2068,6 +2069,8 @@ packages:
       '@svgx/core':
         optional: true
       '@vue/compiler-sfc':
+        optional: true
+      svelte:
         optional: true
       vue-template-compiler:
         optional: true
@@ -4384,7 +4387,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-icons@0.19.3(webpack-sources@3.2.3):
+  unplugin-icons@0.20.0(svelte@5.1.4)(webpack-sources@3.2.3):
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@antfu/utils': 0.7.10
@@ -4393,6 +4396,8 @@ snapshots:
       kolorist: 1.8.0
       local-pkg: 0.5.0
       unplugin: 1.15.0(webpack-sources@3.2.3)
+    optionalDependencies:
+      svelte: 5.1.4
     transitivePeerDependencies:
       - supports-color
       - webpack-sources

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
 		"paths": {
 			"🍎/*": ["./src/*"]
 		},
-		"types": ["vite-plugin-pwa/client"],
+		"types": ["vite-plugin-pwa/svelte", "unplugin-icons/types/svelte"],
 		/**
 		 * Typecheck JS in `.svelte` and `.js` files by default.
 		 * Disable checkJs if you'd like to use dynamic types in JS.


### PR DESCRIPTION
We released yesterday  `unplugin-icons` (v0.20.0) with Svelte 5 stuff: current version using `svelte4.d.ts`, types in Svelte 5 also changed from Svelte 4: https://github.com/unplugin/unplugin-icons/pull/381

This PR also registers proper types for pwa and icons plugins in tsconfig file.